### PR TITLE
Fixing configuration for ND after changes in common configuration

### DIFF
--- a/python/nddaqconf/apps/readout_gen.py
+++ b/python/nddaqconf/apps/readout_gen.py
@@ -224,3 +224,10 @@ class NDReadoutAppGenerator(ReadoutAppGenerator):
                 raise RuntimeError("Card reader could not be created.")
 
         return cr_mods, cr_queues
+
+    def add_volumes_resources(self, readout_app, RU_DESCRIPTOR):
+        # Can be used to add additoinal resources to be mounted on the container
+        # not used for ND 
+        return
+
+


### PR DESCRIPTION
Based on `NND23-11-08` tag. 

Alessandro added a new function (`add_volumes_resources `) in `ReadoutAppGenerator ` [in daqconf](https://github.com/DUNE-DAQ/daqconf/blob/develop/python/daqconf/apps/readout_gen.py)

This is not used now in the ND but breaks the configuration. The same function is defined in the nddaqconf derived class. The function is empty in the ND configuration

Configuration is now successful for the near detector with the changes of this pull request